### PR TITLE
Change CI job to build & test cp313 and cp313t 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,35 +143,16 @@ jobs:
       with:
         matrix_yaml: |
           include:
-          - { platform: manylinux1, arch: x86_64, spec: cp38 }
-          - { platform: manylinux1, arch: x86_64, spec: cp39, omit: ${{ env.skip_ci_redundant_jobs }} }
-          - { platform: manylinux2014, arch: x86_64, spec: cp310, omit: ${{ env.skip_ci_redundant_jobs }} }
-          - { platform: manylinux2014, arch: x86_64, spec: cp311, omit: ${{ env.skip_ci_redundant_jobs }} }
-          - { platform: manylinux2014, arch: x86_64, spec: cp312, omit: ${{ env.skip_ci_redundant_jobs }} }
           - { platform: manylinux2014, arch: x86_64, spec: cp313 }
-          - { platform: manylinux2014, arch: aarch64, spec: cp38, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: manylinux2014, arch: aarch64, spec: cp39, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: manylinux2014, arch: aarch64, spec: cp310, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: manylinux2014, arch: aarch64, spec: cp311, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: manylinux2014, arch: aarch64, spec: cp312, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
           - { platform: manylinux2014, arch: aarch64, spec: cp313, omit: ${{ env.skip_slow_jobs }} }
-          - { platform: manylinux2014, arch: s390x, spec: cp38, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: manylinux2014, arch: s390x, spec: cp39, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: manylinux2014, arch: s390x, spec: cp310, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: manylinux2014, arch: s390x, spec: cp311, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: manylinux2014, arch: s390x, spec: cp312, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
           - { platform: manylinux2014, arch: s390x, spec: cp313, omit: ${{ env.skip_slow_jobs }} }
-          - { platform: musllinux_1_1, arch: x86_64, spec: cp38, omit: ${{ env.skip_ci_redundant_jobs }} }
-          - { platform: musllinux_1_1, arch: x86_64, spec: cp39, omit: ${{ env.skip_ci_redundant_jobs }} }
-          - { platform: musllinux_1_1, arch: x86_64, spec: cp310, omit: ${{ env.skip_ci_redundant_jobs }} }
-          - { platform: musllinux_1_1, arch: x86_64, spec: cp311, omit: ${{ env.skip_ci_redundant_jobs }} }
-          - { platform: musllinux_1_1, arch: x86_64, spec: cp312, omit: ${{ env.skip_ci_redundant_jobs }} }
           - { platform: musllinux_1_1, arch: x86_64, spec: cp313 }
-          - { platform: musllinux_1_1, arch: aarch64, spec: cp39, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: musllinux_1_1, arch: aarch64, spec: cp310, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: musllinux_1_1, arch: aarch64, spec: cp311, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: musllinux_1_1, arch: aarch64, spec: cp312, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
           - { platform: musllinux_1_1, arch: aarch64, spec: cp313, omit: ${{ env.skip_slow_jobs }} }
+          - { platform: manylinux2014, arch: x86_64, spec: cp313t }
+          - { platform: manylinux2014, arch: aarch64, spec: cp313t, omit: ${{ env.skip_slow_jobs }} }
+          - { platform: manylinux2014, arch: s390x, spec: cp313t, omit: ${{ env.skip_slow_jobs }} }
+          - { platform: musllinux_1_1, arch: x86_64, spec: cp313t }
+          - { platform: musllinux_1_1, arch: aarch64, spec: cp313t, omit: ${{ env.skip_slow_jobs }} }
 
 
   linux_pyyaml:
@@ -207,6 +188,7 @@ jobs:
         CIBW_ARCHS: all
         # HACK: ick, maybe deconstruct the matrix a bit or query cibuildwheel for its default target *linux spec first?
         CIBW_BUILD: ${{matrix.spec}}-${{ contains(matrix.platform, 'musllinux') && 'musllinux' || 'manylinux' }}_${{matrix.arch}}
+        CIBW_ENABLE: cpython-prerelease cpython-freethreading
         CIBW_BUILD_VERBOSITY: 1
         # containerized Linux builds require explicit CIBW_ENVIRONMENT
         CIBW_ENVIRONMENT: >
@@ -220,9 +202,8 @@ jobs:
         CIBW_MUSLLINUX_X86_64_IMAGE: ${{ matrix.musllinux_img || 'musllinux_1_1' }}
         CIBW_MUSLLINUX_I686_IMAGE: ${{ matrix.musllinux_img || 'musllinux_1_1' }}
         CIBW_MUSLLINUX_AARCH64_IMAGE: ${{ matrix.musllinux_img || 'musllinux_1_1' }}
-        CIBW_PRERELEASE_PYTHONS: 1
-        CIBW_TEST_COMMAND: cd {project}; pytest
-        CIBW_TEST_REQUIRES: pytest
+        CIBW_TEST_COMMAND: pytest {package} && pytest --parallel-threads=auto --iterations=20 {package}/tests/free_threading
+        CIBW_TEST_REQUIRES: pytest pytest-run-parallel
       run: |
         set -eux
 
@@ -302,46 +283,14 @@ jobs:
       with:
         matrix_yaml: |
           include:
-          - spec: cp38-macosx_x86_64
-            cibw_version: cibuildwheel==2.11.1
-            runs_on: [macos-13]
-            omit: ${{ env.skip_ci_redundant_jobs }}
-          - spec: cp39-macosx_x86_64
-            runs_on: [macos-13]
-            omit: ${{ env.skip_ci_redundant_jobs }}
-          - spec: cp310-macosx_x86_64
-            runs_on: [macos-13]
-            omit: ${{ env.skip_ci_redundant_jobs }}
-          - spec: cp311-macosx_x86_64
-            runs_on: [macos-13]
-            omit: ${{ env.skip_ci_redundant_jobs }}
-          - spec: cp312-macosx_x86_64
-            runs_on: [macos-13]
-            omit: ${{ env.skip_ci_redundant_jobs }}
           - spec: cp313-macosx_x86_64
             runs_on: [macos-13]
-            
-          - spec: cp39-macosx_arm64
-            deployment_target: '11.0'
-            arch: arm64
-            omit: ${{ env.skip_ci_redundant_jobs }}
-  
-          - spec: cp310-macosx_arm64
-            deployment_target: '11.0'
-            arch: arm64
-            omit: ${{ env.skip_ci_redundant_jobs }}
-  
-          - spec: cp311-macosx_arm64
-            deployment_target: '11.0'
-            arch: arm64
-            omit: ${{ env.skip_ci_redundant_jobs }}
-  
-          - spec: cp312-macosx_arm64
-            deployment_target: '11.0'
-            arch: arm64
-            omit: ${{ env.skip_ci_redundant_jobs }}
-  
           - spec: cp313-macosx_arm64
+            deployment_target: '11.0'
+            arch: arm64
+          - spec: cp313t-macosx_x86_64
+            runs_on: [macos-13]
+          - spec: cp313t-macosx_arm64
             deployment_target: '11.0'
             arch: arm64
   
@@ -382,10 +331,10 @@ jobs:
       env:
         C_INCLUDE_PATH: ../libyaml/include
         CIBW_BUILD: ${{matrix.spec}}
+        CIBW_ENABLE: cpython-prerelease cpython-freethreading
         CIBW_BUILD_VERBOSITY: 1
-        CIBW_PRERELEASE_PYTHONS: 1
-        CIBW_TEST_COMMAND: pytest {package}
-        CIBW_TEST_REQUIRES: pytest
+        CIBW_TEST_COMMAND: pytest {package} && pytest --parallel-threads=auto --iterations=20 {package}/tests/free_threading
+        CIBW_TEST_REQUIRES: pytest pytest-run-parallel
         LIBRARY_PATH: ../libyaml/src/.libs
         MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target || '10.9' }}
         PYYAML_FORCE_CYTHON: 1
@@ -468,39 +417,8 @@ jobs:
       with:
         matrix_yaml: |
           include:
-          - spec: cp38-win_amd64
-
-          - spec: cp39-win_amd64
-            omit: ${{ env.skip_ci_redundant_jobs }}
-
-          - spec: cp310-win_amd64
-            omit: ${{ env.skip_ci_redundant_jobs }}
-
-          - spec: cp311-win_amd64
-            omit: ${{ env.skip_ci_redundant_jobs }}
-
-          - spec: cp312-win_amd64
-            omit: ${{ env.skip_ci_redundant_jobs }}
-
           - spec: cp313-win_amd64
-
-          - spec: cp38-win32
-            omit: ${{ env.skip_ci_redundant_jobs }}
-
-          - spec: cp39-win32
-            omit: ${{ env.skip_ci_redundant_jobs }}
-
-          - spec: cp310-win32
-            omit: ${{ env.skip_ci_redundant_jobs }}
-
-          - spec: cp311-win32
-            omit: ${{ env.skip_ci_redundant_jobs }}
-
-          - spec: cp312-win32
-            omit: ${{ env.skip_ci_redundant_jobs }}
-
-          - spec: cp313-win32
-            omit: ${{ env.skip_ci_redundant_jobs }}
+          - spec: cp313t-win_amd64
 
   windows_pyyaml:
     needs: [python_sdist, windows_libyaml, make_windows_pyyaml_matrix]
@@ -540,10 +458,11 @@ jobs:
       shell: bash
       env:
         CIBW_BUILD: ${{matrix.spec}}
+        CIBW_ENABLE: cpython-prerelease cpython-freethreading
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BEFORE_TEST: ls -l {package}
-        CIBW_TEST_COMMAND: pytest {package}
-        CIBW_TEST_REQUIRES: pytest
+        CIBW_TEST_COMMAND: pytest {package} && pytest --parallel-threads=auto --iterations=20 {package}/tests/free_threading
+        CIBW_TEST_REQUIRES: pytest pytest-run-parallel
         CIBW_PRERELEASE_PYTHONS: 1
         #CIBW_CONFIG_SETTINGS: |
         #  pyyaml_build_config='{"include_dirs": ["libyaml/include"], "library_dirs": ["libyaml/build/Release"], "define": [["YAML_DECLARE_STATIC", 1]], "force": 1}'


### PR DESCRIPTION
- Removes older versions from CI
- Enables free-threading on all builds & adds `pytest-run-parallel` tests